### PR TITLE
Enable streaming ZIP generation to reduce memory use

### DIFF
--- a/main.js
+++ b/main.js
@@ -684,7 +684,8 @@ class DicomDeidentifier {
         return await zip.generateAsync({
             type: 'blob',
             compression: 'DEFLATE',
-            compressionOptions: { level: 6 }
+            compressionOptions: { level: 6 },
+            streamFiles: true
         });
     }
     


### PR DESCRIPTION
### Motivation
- Prevent high memory consumption and potential `ArrayBuffer` allocation failures when building large ZIP archives. 
- Use JSZip streaming mode so the archive is not fully concatenated in-memory before download. 

### Description
- Add `streamFiles: true` to the options passed to `zip.generateAsync` in `main.js` to enable streaming ZIP generation. 
- This is a one-line change that keeps existing compression settings (`compression: 'DEFLATE'`, `compressionOptions: { level: 6 }`). 

### Testing
- No automated tests were executed for this change. 
- Change committed to `main.js` and verified the option was added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645e7b1dac832dae9d1bd075089d95)