### PR TITLE
Transfer DICOM ArrayBuffers to/from workers and enable streaming ZIP output

### DIFF
--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -767,6 +767,11 @@ self.onmessage = async function(e) {
         
         // Send completion with results and audit trail
         console.log(`Worker ${workerId}: Generated ${processor.verboseLogs.length} verbose logs, verboseMode was:`, verboseMode);
+        const transferables = results
+            .map(result => result.data)
+            .filter(data => data)
+            .map(data => (ArrayBuffer.isView(data) ? data.buffer : data))
+            .filter(buffer => buffer instanceof ArrayBuffer);
         self.postMessage({
             type: 'COMPLETE',
             workerId: workerId,
@@ -776,7 +781,7 @@ self.onmessage = async function(e) {
             errorLog: processor.generateErrorLog(),
             verboseLogs: processor.verboseLogs,
             skippedFiles: skippedFiles
-        });
+        }, transferables);
     } else {
         console.log('Worker received unknown message type:', type);
     }


### PR DESCRIPTION
### Motivation
- Avoid `DataCloneError` and reduce memory pressure when sending large DICOM payloads between the main thread and workers. 
- Prevent full in-memory cloning of processed buffers when returning results from workers. 
- Reduce overall memory usage when building ZIP archives by enabling streaming output. 

### Description
- Collect transferable buffers from file chunks and pass them to `worker.postMessage(..., transferables)` in `processWithWorkers` and the streaming worker-dispatch path. 
- In `dicom-worker.js`, collect processed `result.data` buffers and pass them as transferables on the `COMPLETE` `postMessage`. 
- Normalize views to underlying buffers using `ArrayBuffer.isView(...)? .buffer : ...` and filter to ensure only `ArrayBuffer` instances are transferred. 
- Enable JSZip streaming by adding `streamFiles: true` to the options passed to `zip.generateAsync` so archives are emitted incrementally. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69645e7b1dac832dae9d1bd075089d95)