### PR TITLE
Add mandatory disclaimer modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -240,6 +240,22 @@
         </footer>
     </div>
 
+    <div id="disclaimerModal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="disclaimerTitle" aria-describedby="disclaimerText">
+        <div class="modal">
+            <h2 id="disclaimerTitle">Disclaimer</h2>
+            <p id="disclaimerText">
+                This tool is provided to assist with the deidentification of radiology imaging data. Use of this tool does not guarantee that all personal identifiers have been removed. In all circumstances, responsibility for ensuring that data is correctly and fully deidentified rests solely with the party transferring the data. Users must independently verify the completeness and correctness of deidentification prior to sharing any data with Harrison.ai. Harrison.ai does not request or seek to receive identified patient data, and use of this tool does not transfer responsibility or liability to Harrison.ai.
+            </p>
+            <label class="modal-checkbox">
+                <input type="checkbox" id="disclaimerCheckbox">
+                <span>I have read and agree to the disclaimer above.</span>
+            </label>
+            <div class="modal-actions">
+                <button id="disclaimerAgreeBtn" class="primary-btn" disabled>Agree &amp; Continue</button>
+            </div>
+        </div>
+    </div>
+
     <script src="scrambler.js"></script>
     <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -70,6 +70,11 @@ class DicomDeidentifier {
         this.loadConfigBtn = document.getElementById('loadConfigBtn');
         this.resetConfigBtn = document.getElementById('resetConfigBtn');
         this.tagConfigList = document.getElementById('tagConfigList');
+
+        // Disclaimer modal elements
+        this.disclaimerModal = document.getElementById('disclaimerModal');
+        this.disclaimerCheckbox = document.getElementById('disclaimerCheckbox');
+        this.disclaimerAgreeBtn = document.getElementById('disclaimerAgreeBtn');
         
         // Bind event listeners
         this.bindEvents();
@@ -79,6 +84,9 @@ class DicomDeidentifier {
         
         // Update process button state
         this.updateProcessButton();
+
+        // Show disclaimer modal on load
+        this.showDisclaimerModal();
     }
     
     bindEvents() {
@@ -196,6 +204,45 @@ class DicomDeidentifier {
         this.resetConfigBtn.addEventListener('click', () => {
             this.resetConfiguration();
         });
+
+        if (this.disclaimerCheckbox) {
+            this.disclaimerCheckbox.addEventListener('change', () => {
+                const isChecked = this.disclaimerCheckbox.checked;
+                this.disclaimerAgreeBtn.disabled = !isChecked;
+            });
+        }
+
+        if (this.disclaimerAgreeBtn) {
+            this.disclaimerAgreeBtn.addEventListener('click', () => {
+                this.hideDisclaimerModal();
+            });
+        }
+    }
+
+    showDisclaimerModal() {
+        if (!this.disclaimerModal) {
+            return;
+        }
+
+        if (this.disclaimerCheckbox) {
+            this.disclaimerCheckbox.checked = false;
+        }
+
+        if (this.disclaimerAgreeBtn) {
+            this.disclaimerAgreeBtn.disabled = true;
+        }
+
+        this.disclaimerModal.classList.remove('hidden');
+        document.body.classList.add('modal-open');
+    }
+
+    hideDisclaimerModal() {
+        if (!this.disclaimerModal) {
+            return;
+        }
+
+        this.disclaimerModal.classList.add('hidden');
+        document.body.classList.remove('modal-open');
     }
     
     handleFileUpload(file) {

--- a/style.css
+++ b/style.css
@@ -12,6 +12,10 @@ body {
     min-height: 100vh;
 }
 
+body.modal-open {
+    overflow: hidden;
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;
@@ -197,6 +201,77 @@ main {
 .checkbox-item span {
     color: #495057;
     user-select: none;
+}
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 1000;
+}
+
+.modal-overlay.hidden {
+    display: none;
+}
+
+.modal {
+    background: #fff;
+    color: #1f2937;
+    max-width: 720px;
+    width: 100%;
+    border-radius: 12px;
+    padding: 28px;
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.25);
+}
+
+.modal h2 {
+    margin-bottom: 12px;
+    font-size: 1.5rem;
+}
+
+.modal p {
+    color: #374151;
+    margin-bottom: 20px;
+}
+
+.modal-checkbox {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    font-size: 0.95rem;
+    margin-bottom: 20px;
+}
+
+.modal-checkbox input[type="checkbox"] {
+    margin-top: 4px;
+    transform: scale(1.1);
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.primary-btn {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    padding: 12px 20px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.primary-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
 }
 
 .progress-section {


### PR DESCRIPTION
### Motivation
- Ensure users explicitly acknowledge a legal/disclaimer notice before using the DICOM de-identification tool so responsibility for correct deidentification remains with the data owner.  

### Description
- Add modal markup to `index.html` containing the provided disclaimer text, a required checkbox, and an `Agree & Continue` button with ARIA attributes for accessibility.  
- Wire modal control into `main.js`: reference modal DOM nodes, show the modal on app initialization via `showDisclaimerModal()`, enable the agree button only when the checkbox is checked, and hide the modal via `hideDisclaimerModal()` when agreed.  
- Add styles to `style.css` to render a blocking overlay, modal layout, button states, a `.hidden` modifier, and `body.modal-open` to lock page scrolling while the modal is shown.  
- The modal is shown on every page load and prevents interaction until the user checks the box and clicks the agree button.  

### Testing
- Started a local server with `python -m http.server` and exercised the UI using a Playwright script that opened `index.html` and captured a screenshot; the script ran and produced `artifacts/disclaimer-modal.png`.  
- The manual UI check via the automated browser run confirmed the modal appears on load, the checkbox enables the button, and the modal hides after agreeing (Playwright run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804e56998c832da8348386a01cd785)