### PR TITLE
Default-select six SOP classes and remove 'Delete' option for not-present tag handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,19 +103,19 @@
                             <span>Digital X-Ray Image Storage - For Processing</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_2" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_2">
                             <span>Digital Mammography X-Ray Image Storage - For Presentation</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_2_1" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_2_1">
                             <span>Digital Mammography X-Ray Image Storage - For Processing</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_3" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_3">
                             <span>Digital Intra-Oral X-Ray Image Storage - For Presentation</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_3_1" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_1_3_1">
                             <span>Digital Intra-Oral X-Ray Image Storage - For Processing</span>
                         </label>
                         <label class="checkbox-item">
@@ -131,23 +131,23 @@
                             <span>Legacy Converted Enhanced CT Image Storage</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4">
                             <span>MR Image Storage</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_1" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_1">
                             <span>Enhanced MR Image Storage</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_2" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_2">
                             <span>MR Spectroscopy Storage</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_3" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_3">
                             <span>Enhanced MR Color Image Storage</span>
                         </label>
                         <label class="checkbox-item">
-                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_4" checked>
+                            <input type="checkbox" id="sopclass_1_2_840_10008_5_1_4_1_1_4_4">
                             <span>Legacy Converted Enhanced MR Image Storage</span>
                         </label>
                         <label class="checkbox-item">

--- a/main.js
+++ b/main.js
@@ -1187,7 +1187,6 @@ class DicomDeidentifier {
                 <div>
                     <div class="scenario-controls">
                         <select class="action-select" data-tag="${tag}" data-scenario="notpresent">
-                            <option value="delete" ${config.ifNotPresent === 'delete' ? 'selected' : ''}>Delete</option>
                             <option value="unchanged" ${config.ifNotPresent === 'unchanged' ? 'selected' : ''}>Unchanged</option>
                             <option value="scrambleFromStudyUID" ${config.ifNotPresent === 'scrambleFromStudyUID' ? 'selected' : ''}>Generate from Study UID</option>
                             <option value="replace" ${config.ifNotPresent === 'replace' ? 'selected' : ''}>Add Value</option>


### PR DESCRIPTION
### Motivation
- Limit default SOP class selections to the six valid storage types to avoid processing unintended modalities.
- Remove the `Delete` option for the "not present" tag configuration because deleting a tag that is already absent is a no-op and the option is misleading.

### Description
- Update `index.html` to only preselect the six valid SOP classes (Computed Radiography, Digital X-Ray Presentation, Digital X-Ray Processing, CT, Enhanced CT, Legacy Converted Enhanced CT) and leave the others unchecked by default.
- Remove the `Delete` option from the `ifNotPresent` dropdown in the tag configuration UI in `main.js` so users can no longer select it for the not-present scenario.
- Adjusted UI rendering logic to reflect the new defaults and options.
- Changes committed with message: "Adjust SOP class defaults and tag config" and modified files `index.html` and `main.js`.

### Testing
- Launched a local HTTP server with `python -m http.server` and captured a full-page screenshot of `index.html` using Playwright to visually verify the updated defaults, which succeeded and produced `artifacts/sopclass-defaults.png`.
- Verified file diffs and committed the changes, commit succeeded. No automated unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804f9899f0832dbe352908d168182f)