### PR TITLE
Fix folder mode processing: stop early termination, double-count, and add cancel with audit save

### DIFF
--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -111,7 +111,11 @@ class DicomProcessor {
         this.errorLog = [];
         this.tagConfigurations = tagConfigurations;
         this.verboseMode = verboseMode;
-        this.verboseLogs = [];
+        // Pre-formatted string instead of array-of-objects: avoids per-tag object
+        // allocation overhead (8M+ objects for large datasets) and redundant filename
+        // storage. Timestamp is emitted once per file, not once per tag.
+        this.verboseLog = '';
+        this._verboseCurrentFile = null;
     }
 
     logError(filename, errorType, errorMessage, sopClassUID = null) {
@@ -126,17 +130,16 @@ class DicomProcessor {
     }
 
     logVerbose(filename, tag, tagName, originalValue, action, newValue) {
-        if (this.verboseMode) {
-            this.verboseLogs.push({
-                filename: filename,
-                tag: tag,
-                tagName: tagName,
-                originalValue: originalValue || '[EMPTY/MISSING]',
-                action: action,
-                newValue: newValue || '[DELETED/UNCHANGED]',
-                timestamp: new Date().toISOString()
-            });
+        if (!this.verboseMode) return;
+        // Emit a per-file header the first time we see a new filename, so the
+        // timestamp is recorded once per file rather than once per tag.
+        if (filename !== this._verboseCurrentFile) {
+            this._verboseCurrentFile = filename;
+            this.verboseLog += `\n--- ${filename} [${new Date().toISOString()}] ---\n`;
         }
+        const orig = originalValue || '[empty]';
+        const next = newValue || '[removed]';
+        this.verboseLog += `  ${tag} (${tagName}): "${orig}" → ${action} → "${next}"\n`;
     }
 
     generateErrorLog() {
@@ -766,7 +769,7 @@ self.onmessage = async function(e) {
         // Worker finished processing all files
         
         // Send completion with results and audit trail
-        console.log(`Worker ${workerId}: Generated ${processor.verboseLogs.length} verbose logs, verboseMode was:`, verboseMode);
+        console.log(`Worker ${workerId}: verboseMode was:`, verboseMode);
         const transferables = results
             .map(result => result.data)
             .filter(data => data)
@@ -777,9 +780,8 @@ self.onmessage = async function(e) {
             workerId: workerId,
             results: results,
             auditTrail: processor.auditTrail,
-            csv: processor.generateCSV(),
             errorLog: processor.generateErrorLog(),
-            verboseLogs: processor.verboseLogs,
+            verboseLog: processor.verboseLog,
             skippedFiles: skippedFiles
         }, transferables);
     } else {

--- a/index.html
+++ b/index.html
@@ -183,6 +183,9 @@
                     <span id="progressPercent">0%</span>
                 </div>
                 <div class="worker-status" id="workerStatus"></div>
+                <button id="cancelBtn" class="cancel-btn" style="display: none;">
+                    Cancel &amp; Save Audit
+                </button>
             </div>
 
             <div class="results-section" id="resultsSection" style="display: none;">

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ class DicomDeidentifier {
 
         // Memory management: max files per worker batch and max total in-flight
         this.BATCH_SIZE = 50;   // files per worker batch dispatch
+        this.aborted = false;
 
         // File System Access API variables
         this.processingMode = 'zip'; // 'zip' or 'folder'
@@ -51,6 +52,7 @@ class DicomDeidentifier {
         this.errorSection = document.getElementById('errorSection');
         this.errorText = document.getElementById('errorText');
         this.resetBtn = document.getElementById('resetBtn');
+        this.cancelBtn = document.getElementById('cancelBtn');
         
         // Folder mode elements
         this.zipModeBtn = document.getElementById('zipModeBtn');
@@ -149,6 +151,17 @@ class DicomDeidentifier {
         this.resetBtn.addEventListener('click', () => {
             this.reset();
         });
+
+        // Cancel button — sets abort flag; workers finish current batch then
+        // finalizeStreamingResults() saves the audit for what was done so far
+        if (this.cancelBtn) {
+            this.cancelBtn.addEventListener('click', () => {
+                this.aborted = true;
+                this.cancelBtn.disabled = true;
+                this.cancelBtn.textContent = 'Cancelling…';
+                this.updateProgress('Cancelling — finishing current batch…', null);
+            });
+        }
         
         // Mode buttons
         if (this.zipModeBtn) {
@@ -372,7 +385,13 @@ class DicomDeidentifier {
 
     async processFiles() {
         try {
+            this.aborted = false;
             this.showProgress();
+            if (this.cancelBtn) {
+                this.cancelBtn.style.display = 'block';
+                this.cancelBtn.disabled = false;
+                this.cancelBtn.textContent = 'Cancel & Save Audit';
+            }
             
             // Get selected SOPClassUIDs
             const allowedSOPClassUIDs = this.getSelectedSOPClassUIDs();
@@ -1061,6 +1080,7 @@ class DicomDeidentifier {
         // Each worker runs a loop: pull next batch → dispatch → wait → repeat
         const runWorker = async (worker, workerIndex) => {
             while (true) {
+                if (this.aborted) break; // abort before reading next batch
                 const batch = await prepareNextBatch();
                 if (!batch) break; // No more files
                 await dispatchBatch(worker, batch, workerIndex);
@@ -1070,11 +1090,15 @@ class DicomDeidentifier {
             }
         };
 
-        // Run all workers concurrently; each pulls batches sequentially from the shared queue
-        await Promise.all(this.workers.map((worker, i) => runWorker(worker, i)));
-
-        // All workers done — finalize
-        await this.finalizeStreamingResults();
+        // Run all workers concurrently; each pulls batches sequentially from the shared queue.
+        // The finally block guarantees finalizeStreamingResults() runs whether processing
+        // completes normally, is aborted, or throws — so the audit CSV is always saved.
+        try {
+            await Promise.all(this.workers.map((worker, i) => runWorker(worker, i)));
+        } finally {
+            this.terminateWorkers();
+            await this.finalizeStreamingResults();
+        }
     }
 
     async saveProcessedFile(result) {
@@ -1149,25 +1173,32 @@ class DicomDeidentifier {
             await logWritable.close();
             // Output log saved
             
-            // Show completion message
+            // Hide cancel button — we're done regardless of how we got here
+            if (this.cancelBtn) this.cancelBtn.style.display = 'none';
+
+            // Show completion message — distinguish normal, aborted, and partial (crash)
             const successCount = this.results.filter(r => r.success).length;
             const failureCount = this.results.filter(r => !r.success).length;
-            
+            const heading = this.aborted
+                ? '<strong>Cancelled — partial results saved</strong>'
+                : `<strong>Processing Complete!</strong>`;
+
             this.resultsText.innerHTML = `
-                <strong>Processing Complete!</strong><br>
-                Successfully processed: ${successCount} files<br>
+                ${heading}<br>
+                Successfully processed: ${successCount} of ${this.totalFiles} files<br>
                 ${failureCount > 0 ? `Failed: ${failureCount} files<br>` : ''}
-                ${this.skippedFiles > 0 ? `Skipped due to SOPClassUID filtering: ${this.skippedFiles} files<br>` : ''}
+                ${this.skippedFiles > 0 ? `Skipped (SOPClassUID filter): ${this.skippedFiles} files<br>` : ''}
                 Files saved to: ${this.outputDirectoryHandle.name}<br>
                 CSV audit trail: deidentification_audit.csv<br>
                 Processing log: output.log<br>
             `;
-            
+
             this.progressSection.style.display = 'none';
             this.resultsSection.style.display = 'block';
             this.downloadBtn.style.display = 'none'; // No download needed in folder mode
-            
+
         } catch (error) {
+            if (this.cancelBtn) this.cancelBtn.style.display = 'none';
             this.showError('Error finalizing results: ' + error.message);
         }
     }
@@ -1202,6 +1233,8 @@ class DicomDeidentifier {
         this.auditTrails = [];
         this.errorLogs = [];
         this.skippedFiles = 0;
+        this.aborted = false;
+        if (this.cancelBtn) this.cancelBtn.style.display = 'none';
         
         // Reset folder paths
         if (this.inputFolderPath) {

--- a/main.js
+++ b/main.js
@@ -13,7 +13,7 @@ class DicomDeidentifier {
         this.results = [];
         this.auditTrails = [];
         this.errorLogs = [];
-        this.verboseLogs = [];
+        this.verboseLog = '';
         this.completedWorkers = 0;
 
         // Memory management: max files per worker batch and max total in-flight
@@ -633,11 +633,8 @@ class DicomDeidentifier {
             this.auditTrails = this.auditTrails.concat(data.auditTrail);
         }
         
-        if (data.verboseLogs) {
-            console.log(`ZIP mode: Received ${data.verboseLogs.length} verbose logs from worker ${workerId}, total now: ${this.verboseLogs.length + data.verboseLogs.length}`);
-            this.verboseLogs = this.verboseLogs.concat(data.verboseLogs);
-        } else {
-            console.log(`ZIP mode: No verbose logs received from worker ${workerId}`);
+        if (data.verboseLog) {
+            this.verboseLog += data.verboseLog;
         }
         if (data.errorLog) {
             this.errorLogs.push(data.errorLog);
@@ -725,21 +722,12 @@ class DicomDeidentifier {
             }
         }
         
-        // Add verbose logs if enabled
-        if (this.verboseMode && this.verboseLogs.length > 0) {
+        if (this.verboseMode && this.verboseLog.length > 0) {
             logContent += '\n\nDetailed Tag Processing Log\n';
-            logContent += '=' .repeat(40) + '\n\n';
-            this.verboseLogs.forEach(log => {
-                logContent += `File: ${log.filename}\n`;
-                logContent += `Tag: ${log.tag} (${log.tagName})\n`;
-                logContent += `Original Value: ${log.originalValue}\n`;
-                logContent += `Action: ${log.action}\n`;
-                logContent += `New Value: ${log.newValue}\n`;
-                logContent += `Time: ${log.timestamp}\n`;
-                logContent += '-'.repeat(50) + '\n';
-            });
+            logContent += '='.repeat(40) + '\n';
+            logContent += this.verboseLog;
         }
-        
+
         zip.file('output.log', logContent);
         
         return await zip.generateAsync({
@@ -861,7 +849,7 @@ class DicomDeidentifier {
                 const worker = this.workers[index];
                 
                 worker.onmessage = async (e) => {
-                    const { type, workerId, results, auditTrail, skippedFiles, verboseLogs, errorLog } = e.data;
+                    const { type, workerId, results, auditTrail, skippedFiles, verboseLog, errorLog } = e.data;
                     // Worker message received
                     
                     if (type === 'COMPLETE') {
@@ -886,9 +874,8 @@ class DicomDeidentifier {
                         }
                         this.auditTrails.push(...(auditTrail || []));
                         
-                        // Collect verbose logs if available
-                        if (verboseLogs && verboseLogs.length > 0) {
-                            this.verboseLogs.push(...verboseLogs);
+                        if (verboseLog) {
+                            this.verboseLog += verboseLog;
                         }
                         
                         // Collect error logs if available
@@ -988,7 +975,7 @@ class DicomDeidentifier {
                     worker.removeEventListener('message', handler);
                     worker.removeEventListener('error', errHandler);
 
-                    const { results, auditTrail, verboseLogs, errorLog, skippedFiles } = e.data;
+                    const { results, auditTrail, verboseLog, errorLog, skippedFiles } = e.data;
 
                     // MM-02: Save to disk immediately, then null out data to free RAM
                     for (const result of (results || [])) {
@@ -1020,9 +1007,8 @@ class DicomDeidentifier {
                         this.auditTrails.push(...auditTrail);
                     }
 
-                    // Collect verbose logs if enabled
-                    if (verboseLogs && verboseLogs.length > 0) {
-                        this.verboseLogs.push(...verboseLogs);
+                    if (verboseLog) {
+                        this.verboseLog += verboseLog;
                     }
 
                     // Collect error logs
@@ -1143,19 +1129,10 @@ class DicomDeidentifier {
                 }
             }
             
-            // Add verbose logs if enabled
-            if (this.verboseMode && this.verboseLogs.length > 0) {
+            if (this.verboseMode && this.verboseLog.length > 0) {
                 logContent += '\n\nDetailed Tag Processing Log\n';
-                logContent += '=' .repeat(40) + '\n\n';
-                this.verboseLogs.forEach(log => {
-                    logContent += `File: ${log.filename}\n`;
-                    logContent += `Tag: ${log.tag} (${log.tagName})\n`;
-                    logContent += `Original Value: ${log.originalValue}\n`;
-                    logContent += `Action: ${log.action}\n`;
-                    logContent += `New Value: ${log.newValue}\n`;
-                    logContent += `Time: ${log.timestamp}\n`;
-                    logContent += '-'.repeat(50) + '\n';
-                });
+                logContent += '='.repeat(40) + '\n';
+                logContent += this.verboseLog;
             }
             
             const logFileHandle = await this.outputDirectoryHandle.getFileHandle('output.log', { create: true });

--- a/main.js
+++ b/main.js
@@ -604,8 +604,16 @@ class DicomDeidentifier {
     }
     
     handleWorkerMessage(event, workerId) {
+        // In folder mode, processWithWorkersQueue manages all progress and
+        // completion via per-batch addEventListener handlers. The onmessage
+        // handler must be a no-op here to avoid double-counting: the worker
+        // sends one PROGRESS message per file (which would increment
+        // processedFiles via updateProgress()) plus one COMPLETE per batch
+        // (which handleWorkerComplete would mishandle).
+        if (this.processingMode === 'folder') return;
+
         const { type } = event.data;
-        
+
         if (type === 'PROGRESS') {
             this.updateProgress();
         } else if (type === 'COMPLETE') {

--- a/main.js
+++ b/main.js
@@ -619,6 +619,11 @@ class DicomDeidentifier {
     }
     
     handleWorkerComplete(data, workerId) {
+        // In folder mode, processWithWorkersQueue manages COMPLETE messages directly
+        // via per-batch addEventListener handlers. Handling them here too causes
+        // premature termination after the first round of batches.
+        if (this.processingMode === 'folder') return;
+
         console.log('Worker', workerId, 'completed with data:', data);
         
         if (data.results) {

--- a/style.css
+++ b/style.css
@@ -140,6 +140,29 @@ main {
     transform: translateY(-2px);
 }
 
+.cancel-btn {
+    background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+    color: white;
+    border: none;
+    padding: 10px 24px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    margin: 16px auto 0;
+    display: block;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.cancel-btn:hover:not(:disabled) {
+    transform: translateY(-2px);
+}
+
+.cancel-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .process-btn:disabled {
     background: #ccc;
     cursor: not-allowed;


### PR DESCRIPTION
## Summary

- **Fix folder mode stopping after first batch round** — `handleWorkerComplete` fired on every `COMPLETE` message via `worker.onmessage`, causing premature `terminateWorkers()` after only `workerCount × BATCH_SIZE` files
- **Fix progress counter exceeding total files** — worker sends one `PROGRESS` message per file; `handleWorkerMessage` was calling `updateProgress()` (which increments `processedFiles`) for each, doubling the count on top of the per-result increment in `dispatchBatch`
- **Remove unused CSV generation per batch** — worker called `processor.generateCSV()` on every `COMPLETE` and sent it over postMessage, but no consumer in either mode ever read it
- **Cut verbose log memory overhead** — replaced 8M+ per-tag JS objects `{filename, tag, tagName, originalValue, action, newValue, timestamp}` with a pre-formatted string; timestamp now emitted once per file as a section header rather than once per tag; eliminates ~1.5–2.5 GB heap pressure in verbose mode at 80k-file scale
- **Add Cancel button with guaranteed audit save** — cancel sets an abort flag checked between batches (no partial files); `processWithWorkersQueue` wraps `Promise.all` in try/finally so `deidentification_audit.csv` and `output.log` are always written to the output folder whether processing completes, is cancelled, or throws

## Test plan

- [ ] Run folder mode against a large dataset (80k+ files) and verify all files are processed and progress reaches 100%
- [ ] Verify progress counter does not exceed total file count
- [ ] Click Cancel mid-run and confirm `deidentification_audit.csv` is written to output folder with partial results
- [ ] Verify zip mode still works correctly (all guards are folder-mode-only)
- [ ] Check verbose mode output log has correct per-file headers with one line per tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)