### PR TITLE
Add Decompress + Process DICOM Files button and worker-side decompression

### DIFF
--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -9,6 +9,7 @@ const baseUrl = self.location.href.substring(0, self.location.href.lastIndexOf('
 importScripts(baseUrl + '/jszip.min.js');
 importScripts(baseUrl + '/dcmjs.min.js');
 importScripts(baseUrl + '/scrambler.js');
+importScripts('https://unpkg.com/dcmjs-codecs@0.0.6/build/dcmjs-codecs.min.js');
 
 // DICOM tag whitelist - only these tags will be kept
 const WHITELISTED_TAGS = {
@@ -105,12 +106,13 @@ const SCRAMBLE_TIME_TAGS = ['00080030', '00080031', '00080032', '00080033'];
 const SCRAMBLE_TEXT_TAGS = ['00080050', '00100010', '00100020', '00080080'];
 
 class DicomProcessor {
-    constructor(passphrase, tagConfigurations = {}, verboseMode = false) {
+    constructor(passphrase, tagConfigurations = {}, verboseMode = false, decompressMode = false) {
         this.scrambler = new DicomScrambler(passphrase);
         this.auditTrail = [];
         this.errorLog = [];
         this.tagConfigurations = tagConfigurations;
         this.verboseMode = verboseMode;
+        this.decompressMode = decompressMode;
         // Pre-formatted string instead of array-of-objects: avoids per-tag object
         // allocation overhead (8M+ objects for large datasets) and redundant filename
         // storage. Timestamp is emitted once per file, not once per tag.
@@ -308,6 +310,27 @@ class DicomProcessor {
         }
     }
 
+
+
+    async decompressIfRequested(dataSet, filename) {
+        if (!this.decompressMode) return;
+        const transferSyntax = this.getTagValue(dataSet.meta, '00020010');
+        if (!transferSyntax || transferSyntax === '1.2.840.10008.1.2.1') return;
+
+        try {
+            const denat = dcmjs.data.DicomMetaDictionary.naturalizeDataset(dataSet.dict);
+            denat._meta = dcmjs.data.DicomMetaDictionary.namifyDataset(dataSet.meta);
+            const codec = new dcmjsCodecs.Codec();
+            const decoded = codec.decode(denat, transferSyntax, '1.2.840.10008.1.2.1');
+            const renat = dcmjs.data.DicomMetaDictionary.denaturalizeDataset(decoded);
+            dataSet.dict = renat;
+            dataSet.meta['00020010'] = { vr: 'UI', Value: ['1.2.840.10008.1.2.1'] };
+            this.logVerbose(filename, '00020010', 'TransferSyntaxUID', transferSyntax, 'DECOMPRESS', '1.2.840.10008.1.2.1');
+        } catch (e) {
+            this.logError(filename, 'DECOMPRESS_ERROR', e.message);
+            throw new Error(`Unable to decompress pixel data: ${e.message}`);
+        }
+    }
     async processDicomFile(arrayBuffer, filename) {
         // Processing DICOM file
         try {
@@ -316,6 +339,7 @@ class DicomProcessor {
             const dataSet = dcmjs.data.DicomMessage.readFile(arrayBuffer);
             const dict = dataSet.dict;
             // DICOM data parsed
+            await this.decompressIfRequested(dataSet, filename);
             
             // Extract original values for audit trail
             // Extracting original values
@@ -710,17 +734,17 @@ self.onmessage = async function(e) {
     const { type } = e.data;
     
     if (type === 'PROCESS_FILES' || type === 'PROCESS_CHUNK') {
-        let files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode;
+        let files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode, decompressMode;
         
         if (type === 'PROCESS_FILES') {
-            ({ files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode } = e.data.data);
+            ({ files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode, decompressMode } = e.data.data);
         } else {
-            ({ files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode } = e.data);
+            ({ files, passphrase, workerId, allowedSOPClassUIDs, tagConfigurations, verboseMode, decompressMode } = e.data);
         }
         
         // Worker starting file processing
         // SOPClassUIDs configured
-        const processor = new DicomProcessor(passphrase, tagConfigurations, verboseMode);
+        const processor = new DicomProcessor(passphrase, tagConfigurations, verboseMode, decompressMode);
         const results = [];
         let skippedFiles = 0;
         

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="jszip.min.js"></script>
     <script src="dcmjs.min.js"></script>
+    <script src="https://unpkg.com/dcmjs-codecs@0.0.6/build/dcmjs-codecs.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -165,12 +166,22 @@
                     </div>
                 </div>
 
+                <div class="action-buttons">
                 <button id="processBtn" class="process-btn" disabled>
                     <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <polygon points="5,3 19,12 5,21 5,3"/>
                     </svg>
                     Process DICOM Files
                 </button>
+                <button id="decompressBtn" class="process-btn" disabled>
+                    <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M12 3v12"/>
+                        <polyline points="7,11 12,16 17,11"/>
+                        <rect x="4" y="17" width="16" height="4" rx="1"/>
+                    </svg>
+                    Decompress + Process DICOM Files
+                </button>
+                </div>
             </div>
 
             <div class="progress-section" id="progressSection" style="display: none;">
@@ -186,6 +197,7 @@
                 <button id="cancelBtn" class="cancel-btn" style="display: none;">
                     Cancel &amp; Save Audit
                 </button>
+                </div>
             </div>
 
             <div class="results-section" id="resultsSection" style="display: none;">

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ class DicomDeidentifier {
         this.errorLogs = [];
         this.verboseLog = '';
         this.completedWorkers = 0;
+        this.decompressMode = false;
 
         // Memory management: max files per worker batch and max total in-flight
         this.BATCH_SIZE = 50;   // files per worker batch dispatch
@@ -41,6 +42,7 @@ class DicomDeidentifier {
         this.uploadArea = document.getElementById('uploadArea');
         this.fileInput = document.getElementById('fileInput');
         this.processBtn = document.getElementById('processBtn');
+        this.decompressBtn = document.getElementById('decompressBtn');
         this.progressSection = document.getElementById('progressSection');
         this.progressFill = document.getElementById('progressFill');
         this.progressText = document.getElementById('progressText');
@@ -139,6 +141,11 @@ class DicomDeidentifier {
         
         // Process button
         this.processBtn.addEventListener('click', () => {
+            this.decompressMode = false;
+            this.processFiles();
+        });
+        this.decompressBtn.addEventListener('click', () => {
+            this.decompressMode = true;
             this.processFiles();
         });
         
@@ -289,6 +296,7 @@ class DicomDeidentifier {
         }
         
         this.processBtn.disabled = !canProcess;
+        this.decompressBtn.disabled = !canProcess;
     }
     
     switchToMode(mode) {
@@ -613,7 +621,8 @@ class DicomDeidentifier {
                         workerId: index,
                         allowedSOPClassUIDs: this.allowedSOPClassUIDs,
                         tagConfigurations: this.tagConfigurations,
-                        verboseMode: this.verboseMode
+                        verboseMode: this.verboseMode,
+                    decompressMode: this.decompressMode
                     }
                 }, transferables);
             }
@@ -946,7 +955,8 @@ class DicomDeidentifier {
                     workerId: index,
                     allowedSOPClassUIDs: this.allowedSOPClassUIDs,
                     tagConfigurations: this.tagConfigurations,
-                    verboseMode: this.verboseMode
+                    verboseMode: this.verboseMode,
+                    decompressMode: this.decompressMode
                 }, transferables);
             });
         });
@@ -1072,7 +1082,8 @@ class DicomDeidentifier {
                     workerId: workerIndex,
                     allowedSOPClassUIDs: this.allowedSOPClassUIDs,
                     tagConfigurations: this.tagConfigurations,
-                    verboseMode: this.verboseMode
+                    verboseMode: this.verboseMode,
+                    decompressMode: this.decompressMode
                 }, transferables);
             });
         };

--- a/style.css
+++ b/style.css
@@ -140,6 +140,18 @@ main {
     transform: translateY(-2px);
 }
 
+
+.action-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 30px;
+}
+
+.action-buttons .process-btn {
+    margin: 0;
+}
 .cancel-btn {
     background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
     color: white;


### PR DESCRIPTION
### Motivation
- Provide an option to decompress compressed DICOM pixel data prior to de-identification so output files use an uncompressed transfer syntax (`1.2.840.10008.1.2.1`).
- Allow users to run the existing processing pipeline while also performing pixel data decode and updating the File Meta `TransferSyntaxUID` in a single action.

### Description
- Added a new UI button `decompressBtn` and layout wrapper so users can choose `Decompress + Process DICOM Files` alongside the existing process action. 
- Included the `dcmjs-codecs` runtime in `index.html` and loaded it into the worker with `importScripts` so the worker can decode compressed transfer syntaxes. 
- Introduced `decompressMode` in `main.js`, wired the button handlers to set that flag, and threaded `decompressMode` through worker dispatch (`PROCESS_FILES` / `PROCESS_CHUNK`) so workers know when to decompress. 
- Implemented `decompressIfRequested()` in `dicom-worker.js` (used by `DicomProcessor`) which decodes pixel data via `dcmjsCodecs.Codec`, replaces the dataset with the decoded pixels, and forces `TransferSyntaxUID` to `1.2.840.10008.1.2.1`, while logging successes and reporting decompression failures as `DECOMPRESS_ERROR`. 
- Minor styling change in `style.css` to position the two action buttons neatly.

### Testing
- Ran `node --check main.js` and it completed successfully. 
- Ran `node --check dicom-worker.js` and it completed successfully. 
- Verified changed files staged and committed locally and created PR metadata for the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f158fbe590832dbaeeff4c54a2f579)