### PR TITLE
Gracefully handle dcmjs-codecs WASM init/transcoder failures and skip decompression

### DIFF
--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -9,7 +9,8 @@ const baseUrl = self.location.href.substring(0, self.location.href.lastIndexOf('
 importScripts(baseUrl + '/jszip.min.js');
 importScripts(baseUrl + '/dcmjs.min.js');
 importScripts(baseUrl + '/scrambler.js');
-importScripts('https://unpkg.com/dcmjs-codecs@0.0.6/build/dcmjs-codecs.min.js');
+const DCMJS_CODECS_BASE_URL = 'https://cdn.jsdelivr.net/npm/dcmjs-codecs@0.0.6/build';
+importScripts(`${DCMJS_CODECS_BASE_URL}/dcmjs-codecs.min.js`);
 let codecsInitPromise = null;
 
 // DICOM tag whitelist - only these tags will be kept
@@ -319,7 +320,11 @@ class DicomProcessor {
             if (!nativeCodecs || typeof nativeCodecs.initializeAsync !== 'function') {
                 throw new Error('dcmjs-codecs NativeCodecs.initializeAsync is unavailable');
             }
-            codecsInitPromise = nativeCodecs.initializeAsync({ logCodecsInfo: false, logCodecsTrace: false });
+            codecsInitPromise = nativeCodecs.initializeAsync({
+                webAssemblyModulePathOrUrl: `${DCMJS_CODECS_BASE_URL}/dcmjs-native-codecs.wasm`,
+                logCodecsInfo: false,
+                logCodecsTrace: false
+            });
         }
         return codecsInitPromise;
     }

--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -326,6 +326,10 @@ class DicomProcessor {
 
     async decompressIfRequested(arrayBuffer, filename) {
         if (!this.decompressMode) return { arrayBuffer, transferSyntax: null, decompressed: false };
+        if (!(arrayBuffer instanceof ArrayBuffer)) {
+            this.logError(filename, 'DECOMPRESS_INVALID_INPUT', 'Expected ArrayBuffer input for decompression');
+            return { arrayBuffer, transferSyntax: null, decompressed: false };
+        }
 
         const parsed = dcmjs.data.DicomMessage.readFile(arrayBuffer);
         const transferSyntax = this.getTagValue(parsed.meta, '00020010');
@@ -373,7 +377,6 @@ class DicomProcessor {
             const dataSet = dcmjs.data.DicomMessage.readFile(decompressResult.arrayBuffer);
             const dict = dataSet.dict;
             // DICOM data parsed
-            await this.decompressIfRequested(dataSet, filename);
             
             // Extract original values for audit trail
             // Extracting original values

--- a/dicom-worker.js
+++ b/dicom-worker.js
@@ -333,13 +333,23 @@ class DicomProcessor {
             return { arrayBuffer, transferSyntax, decompressed: false };
         }
 
-        await this.ensureCodecsInitialized();
+        try {
+            await this.ensureCodecsInitialized();
+        } catch (e) {
+            // If WASM codecs fail to load (e.g., CDN/network/CORS issues), continue
+            // processing without decompression so de-identification can still proceed.
+            this.logError(filename, 'DECOMPRESS_CODEC_INIT_ERROR', e.message);
+            this.logVerbose(filename, '00020010', 'TransferSyntaxUID', transferSyntax, 'DECOMPRESS_SKIPPED', transferSyntax);
+            return { arrayBuffer, transferSyntax, decompressed: false };
+        }
 
         const transferrer = self.dcmjsCodecs?.Transcoder;
         const explicitLE = self.dcmjsCodecs?.constants?.TransferSyntax?.ExplicitVRLittleEndian || '1.2.840.10008.1.2.1';
 
         if (!transferrer) {
-            throw new Error('dcmjs-codecs Transcoder is unavailable');
+            this.logError(filename, 'DECOMPRESS_TRANSCODER_UNAVAILABLE', 'dcmjs-codecs Transcoder is unavailable');
+            this.logVerbose(filename, '00020010', 'TransferSyntaxUID', transferSyntax, 'DECOMPRESS_SKIPPED', transferSyntax);
+            return { arrayBuffer, transferSyntax, decompressed: false };
         }
 
         try {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css">
     <script src="jszip.min.js"></script>
     <script src="dcmjs.min.js"></script>
-    <script src="https://unpkg.com/dcmjs-codecs@0.0.6/build/dcmjs-codecs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dcmjs-codecs@0.0.6/build/dcmjs-codecs.min.js"></script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
### Motivation
- Some environments fail to initialize the `dcmjs-codecs` WASM (e.g., CDN/CORS/network issues), causing `WebAssembly.instantiate` errors that abort DICOM processing; the change ensures de-identification can continue when decompression is unavailable. 
- The goal is to make file processing resilient by logging codec failures and falling back to processing the original buffer without decompression.

### Description
- Wrapped `ensureCodecsInitialized()` in a `try/catch` inside `decompressIfRequested` and log a `DECOMPRESS_CODEC_INIT_ERROR` while returning the original buffer so processing continues without decompression. 
- Replaced the hard throw for a missing `Transcoder` with logging `DECOMPRESS_TRANSCODER_UNAVAILABLE` and a safe early return that skips decompression. 
- Preserved existing behavior for actual transcode runtime errors by continuing to log `DECOMPRESS_ERROR` and surface the failure when transcoding fails.

### Testing
- Ran the repository test command `npm test -- --runInBand`, which exits with `Error: no test specified` because this repo has no automated test script defined. 
- Verified by static inspection that `dicom-worker.js` now logs codec/transcoder initialization issues and returns the original buffer when decompression cannot proceed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1606429c4832db18228a0cf65a012)